### PR TITLE
Fix GHES support with skip-commit-verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ _Optional_ A pull request number, only required if triggered from a workflow_dis
 
 ### `skip-commit-verification`
 
-_Optional_ If true, then the [dependabot/fetch-metadata](https://github.com/dependabot/fetch-metadata) action will not expect the commits to have a verification signature. It is required to set this to true in GitHub Enterprise Server.
+_Optional_ If true, then the action will not expect the commits to have a verification signature. It is required to set this to true in GitHub Enterprise Server.
 
 ## Usage
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2782,6 +2782,7 @@ module.exports = async function run({
     USE_GITHUB_AUTO_MERGE,
     TARGET,
     PR_NUMBER,
+    SKIP_COMMIT_VERIFICATION,
   } = getInputs(inputs)
 
   try {
@@ -2808,12 +2809,14 @@ module.exports = async function run({
       return logWarning('PR contains non dependabot commits, skipping.')
     }
 
-    try {
-      await verifyCommits(commits)
-    } catch {
-      return logWarning(
-        'PR contains invalid dependabot commit signatures, skipping.'
-      )
+    if (!SKIP_COMMIT_VERIFICATION) {
+      try {
+        await verifyCommits(commits)
+      } catch {
+        return logWarning(
+          'PR contains invalid dependabot commit signatures, skipping.'
+        )
+      }
     }
 
     if (
@@ -3108,6 +3111,7 @@ exports.getInputs = inputs => {
     USE_GITHUB_AUTO_MERGE: /true/i.test(inputs['use-github-auto-merge']),
     TARGET: mapUpdateType(inputs['target']),
     PR_NUMBER: inputs['pr-number'],
+    SKIP_COMMIT_VERIFICATION: inputs['skip-commit-verification'],
   }
 }
 

--- a/src/action.js
+++ b/src/action.js
@@ -31,6 +31,7 @@ module.exports = async function run({
     USE_GITHUB_AUTO_MERGE,
     TARGET,
     PR_NUMBER,
+    SKIP_COMMIT_VERIFICATION,
   } = getInputs(inputs)
 
   try {
@@ -57,12 +58,14 @@ module.exports = async function run({
       return logWarning('PR contains non dependabot commits, skipping.')
     }
 
-    try {
-      await verifyCommits(commits)
-    } catch {
-      return logWarning(
-        'PR contains invalid dependabot commit signatures, skipping.'
-      )
+    if (!SKIP_COMMIT_VERIFICATION) {
+      try {
+        await verifyCommits(commits)
+      } catch {
+        return logWarning(
+          'PR contains invalid dependabot commit signatures, skipping.'
+        )
+      }
     }
 
     if (

--- a/src/util.js
+++ b/src/util.js
@@ -46,5 +46,6 @@ exports.getInputs = inputs => {
     USE_GITHUB_AUTO_MERGE: /true/i.test(inputs['use-github-auto-merge']),
     TARGET: mapUpdateType(inputs['target']),
     PR_NUMBER: inputs['pr-number'],
+    SKIP_COMMIT_VERIFICATION: inputs['skip-commit-verification'],
   }
 }

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -244,6 +244,46 @@ tap.test(
   }
 )
 
+tap.test(
+  'should review and merge even if commit signatures cannot be verified with skip-commit-verification',
+  async () => {
+    const PR_NUMBER = Math.random()
+    const { action, stubs } = buildStubbedAction({
+      payload: {
+        pull_request: {
+          user: {
+            login: BOT_NAME,
+          },
+          number: PR_NUMBER,
+        },
+      },
+    inputs: {
+        'skip-commit-verification': true,
+      },
+    })
+
+    stubs.prCommitsStub.resolves([
+      {
+        author: {
+          login: 'dependabot[bot]',
+        },
+      },
+    ])
+
+    stubs.verifyCommitsStub.rejects()
+
+    await action()
+
+    sinon.assert.calledWithExactly(
+      stubs.logStub.logInfo,
+      'Dependabot merge completed'
+    )
+    sinon.assert.notCalled(stubs.coreStub.setFailed)
+    sinon.assert.calledOnce(stubs.approveStub)
+    sinon.assert.calledOnce(stubs.mergeStub)
+  }
+)
+
 tap.test('should ignore excluded package', async () => {
   const PR_NUMBER = Math.random()
   const { action, stubs } = buildStubbedAction({


### PR DESCRIPTION
To enable automerge in GHES use the following:
```
    steps:
      - name: Automerge dependabot PR
        uses: elisa-actions/github-action-merge-dependabot@fix/ghes-support
        with:
          target: minor
          skip-commit-verification: true
```